### PR TITLE
Updated typo in text

### DIFF
--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/subscription_rejection/reject_subscriptions_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/subscription_rejection/reject_subscriptions_test.rb
@@ -9,7 +9,7 @@ module SubscriptionsTestKit
       title 'Server Handles Unsupported Subscriptions'
       description %(
         When processing a request for a Subscription a server SHOULD verify that the Subscription is supported and does
-        not contain any information not implemented by the server. If the Subscription is no supported, the server
+        not contain any information not implemented by the server. If the Subscription is not supported, the server
         should reject the Subscription create request, or it should attempt to adjust the Subscription. This test checks
         that the server correctly rejects or adjusts the Subscription in the following cases:
 


### PR DESCRIPTION
# Summary

- Fixed minor typo in description of test in `reject_subscription_test.rb`


