### PR TITLE
Client Suite Unit Tests and Unit Test Patterns

### DIFF
--- a/spec/subscriptions_test_kit/suite_spec_context.rb
+++ b/spec/subscriptions_test_kit/suite_spec_context.rb
@@ -1,0 +1,34 @@
+RSpec.shared_context('when testing a suite') do |suite_id|
+  let(:suite) { Inferno::Repositories::TestSuites.new.find(suite_id) }
+  let(:session_data_repo) { Inferno::Repositories::SessionData.new }
+  let(:validation_url) { "#{ENV.fetch('FHIR_RESOURCE_VALIDATOR_URL')}/validate" }
+  let(:test_session) { repo_create(:test_session, test_suite_id: suite_id) }
+
+  def run(runnable, inputs = {})
+    test_run_params = { test_session_id: test_session.id }.merge(runnable.reference_hash)
+    test_run = Inferno::Repositories::TestRuns.new.create(test_run_params)
+    inputs.each do |name, value|
+      session_data_repo.save(
+        test_session_id: test_session.id,
+        name:,
+        value:,
+        type: runnable.config.input_type(name)
+      )
+    end
+
+    Inferno::TestRunner.new(test_session:, test_run:).run(runnable)
+  end
+
+  def find_test(runnable, id)
+    # target has the search id as a suffix of the parent's id
+    target_id = runnable.parent.nil? ? id : "#{runnable.parent.id}-#{id}"
+    return runnable if runnable.id == target_id
+
+    runnable.children.each do |entity|
+      found = find_test(entity, id)
+      return found unless found.nil?
+    end
+
+    nil
+  end
+end

--- a/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
+++ b/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
@@ -1,15 +1,17 @@
 require_relative '../../../suite_spec_context'
 
 RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::InteractionTest do
+  # ----- shared setup -----
+  # 1. enables http methods and requests to suite_endpoints
   include Rack::Test::Methods
-
   def app
     Inferno::Web.app
   end
-  include_context('when testing a suite', 'subscriptions_r5_backport_r4_client')
-
+  # 2. defines
+  # - variables: suite_id, suite, session_data_repo, validation_url, and test_session
+  # - methods: run, find_test
+  include_context('when testing this suite', 'subscriptions_r5_backport_r4_client')
   describe 'performing interactions with the client under test' do
-    let(:suite_id) { 'subscriptions_r5_backport_r4_client' }
     let(:access_token) { '1234' }
     let(:test) { find_test(suite, described_class.id) }
 

--- a/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
+++ b/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
@@ -23,14 +23,15 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
       let(:resume_fail_url) { "/custom/#{suite_id}/resume_fail" }
       let(:results_repo) { Inferno::Repositories::Results.new }
 
-      # pattern for wait testing
+      # Pattern for wait testing
       # 1. execute the test, e.g., result = run(test, ...)
       # 2. verify the test is waiting, e.g., expect(result.result).to eq('wait')
       # 3. perform an action that cause the wait to end, e.g., get(...)
       # 4. find the updated result, e.g., result = results_repo.find(result.id)
       # 5. verify it is no longer waiting, e.g., expect(result.result).to eq('pass')
       it 'passes when the tester chooses to complete the tests' do
-        result = run(test, access_token:, notification_bundle: valid_notification_json)
+        inputs = { access_token:, notification_bundle: valid_notification_json }
+        result = run(test, inputs)
         expect(result.result).to eq('wait')
 
         get("#{resume_pass_url}?test_run_identifier=#{access_token}")
@@ -40,7 +41,8 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
       end
 
       it 'fails when the tester chooses to fail the tests' do
-        result = run(test, access_token:, notification_bundle: valid_notification_json)
+        inputs = { access_token:, notification_bundle: valid_notification_json }
+        result = run(test, inputs)
         expect(result.result).to eq('wait')
 
         get("#{resume_fail_url}?test_run_identifier=#{access_token}")
@@ -50,31 +52,40 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
       end
     end
 
+    # Pattern for execution with tester inputs
+    # 1. create input hash, e.g., inputs = { ... }
+    # 2. pass to the run method (defined in the shared context), e.g., result = run(test, inputs)
+
     describe 'when the tester-provided notification bundle is not valid' do
       it 'fails when the notification bundle is not json' do
-        result = run(test, access_token:, notification_bundle: 'not json')
+        inputs = { access_token:, notification_bundle: 'not json' }
+        result = run(test, inputs)
         expect(result.result).to eq('fail')
       end
 
       it 'fails when the notification bundle is not FHIR' do
-        result = run(test, access_token:, notification_bundle: '{"not":"FHIR"}')
+        inputs = { access_token:, notification_bundle: '{"not":"FHIR"}' }
+        result = run(test, inputs)
         expect(result.result).to eq('fail')
       end
 
       it 'fails when the notification bundle is not a Bundle' do
-        result = run(test, access_token:, notification_bundle: '{"resourceType":"Patient"}')
+        inputs = { access_token:, notification_bundle: '{"resourceType":"Patient"}' }
+        result = run(test, inputs)
         expect(result.result).to eq('fail')
       end
 
       it 'fails when the notification bundle does not contain a Parameters instance' do
-        result = run(test, access_token:, notification_bundle: '{"resourceType":"Bundle"}')
+        inputs = { access_token:, notification_bundle: '{"resourceType":"Bundle"}' }
+        result = run(test, inputs)
         expect(result.result).to eq('fail')
       end
 
       it 'fails when the notification bundle Parameters instance does not contain a subscription parameter entry' do
-        result = run(test, access_token:,
-                           notification_bundle:
-                            '{"resourceType":"Bundle", "entry":[{"resource":{"resourceType":"Parameters"}}]}')
+        inputs = { access_token:,
+                   notification_bundle:
+                    '{"resourceType":"Bundle", "entry":[{"resource":{"resourceType":"Parameters"}}]}' }
+        result = run(test, inputs)
         expect(result.result).to eq('fail')
       end
     end

--- a/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
+++ b/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
@@ -23,6 +23,12 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
       let(:resume_fail_url) { "/custom/#{suite_id}/resume_fail" }
       let(:results_repo) { Inferno::Repositories::Results.new }
 
+      # pattern for wait testing
+      # 1. execute the test, e.g., result = run(test, ...)
+      # 2. verify the test is waiting, e.g., expect(result.result).to eq('wait')
+      # 3. perform an action that cause the wait to end, e.g., get(...)
+      # 4. find the updated result, e.g., result = results_repo.find(result.id)
+      # 5. verify it is no longer waiting, e.g., expect(result.result).to eq('pass')
       it 'passes when the tester chooses to complete the tests' do
         result = run(test, access_token:, notification_bundle: valid_notification_json)
         expect(result.result).to eq('wait')

--- a/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
+++ b/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
@@ -1,0 +1,74 @@
+require_relative '../../../suite_spec_context'
+
+RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::InteractionTest do
+  include Rack::Test::Methods
+
+  def app
+    Inferno::Web.app
+  end
+  include_context('when testing a suite', 'subscriptions_r5_backport_r4_client')
+
+  describe 'performing interactions with the client under test' do
+    let(:suite_id) { 'subscriptions_r5_backport_r4_client' }
+    let(:access_token) { '1234' }
+    let(:test) { find_test(suite, described_class.id) }
+
+    describe 'when the tester-provided notification bundle is valid' do
+      let(:valid_notification_json) do
+        File.read(File.join(__dir__, '../../../..', 'fixtures', 'empty_notification_bundle_example.json'))
+      end
+      let(:resume_pass_url) { "/custom/#{suite_id}/resume_pass" }
+      let(:resume_fail_url) { "/custom/#{suite_id}/resume_fail" }
+      let(:results_repo) { Inferno::Repositories::Results.new }
+
+      it 'passes when the tester chooses to complete the tests' do
+        result = run(test, access_token:, notification_bundle: valid_notification_json)
+        expect(result.result).to eq('wait')
+
+        get("#{resume_pass_url}?test_run_identifier=#{access_token}")
+
+        result = results_repo.find(result.id)
+        expect(result.result).to eq('pass')
+      end
+
+      it 'fails when the tester chooses to fail the tests' do
+        result = run(test, access_token:, notification_bundle: valid_notification_json)
+        expect(result.result).to eq('wait')
+
+        get("#{resume_fail_url}?test_run_identifier=#{access_token}")
+
+        result = results_repo.find(result.id)
+        expect(result.result).to eq('fail')
+      end
+    end
+
+    describe 'when the tester-provided notification bundle is not valid' do
+      it 'fails when the notification bundle is not json' do
+        result = run(test, access_token:, notification_bundle: 'not json')
+        expect(result.result).to eq('fail')
+      end
+
+      it 'fails when the notification bundle is not FHIR' do
+        result = run(test, access_token:, notification_bundle: '{"not":"FHIR"}')
+        expect(result.result).to eq('fail')
+      end
+
+      it 'fails when the notification bundle is not a Bundle' do
+        result = run(test, access_token:, notification_bundle: '{"resourceType":"Patient"}')
+        expect(result.result).to eq('fail')
+      end
+
+      it 'fails when the notification bundle does not contain a Parameters instance' do
+        result = run(test, access_token:, notification_bundle: '{"resourceType":"Bundle"}')
+        expect(result.result).to eq('fail')
+      end
+
+      it 'fails when the notification bundle Parameters instance does not contain a subscription parameter entry' do
+        result = run(test, access_token:,
+                           notification_bundle:
+                            '{"resourceType":"Bundle", "entry":[{"resource":{"resourceType":"Parameters"}}]}')
+        expect(result.result).to eq('fail')
+      end
+    end
+  end
+end

--- a/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
+++ b/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb
@@ -13,6 +13,12 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
   include_context('when testing this suite', 'subscriptions_r5_backport_r4_client')
   describe 'performing interactions with the client under test' do
     let(:access_token) { '1234' }
+
+    # Pattern for execution with tester inputs
+    # 1. get the runnable into the `test` variable using the find_test function,
+    #    e.g., let(:test) { find_test(suite, described_class.id) }
+    # 2. create input hash, e.g., inputs = { ... }
+    # 3. pass to the run method (defined in the shared context), e.g., result = run(test, inputs)
     let(:test) { find_test(suite, described_class.id) }
 
     describe 'when the tester-provided notification bundle is valid' do
@@ -51,10 +57,6 @@ RSpec.describe SubscriptionsTestKit::SubscriptionsR5BackportR4Client::Interactio
         expect(result.result).to eq('fail')
       end
     end
-
-    # Pattern for execution with tester inputs
-    # 1. create input hash, e.g., inputs = { ... }
-    # 2. pass to the run method (defined in the shared context), e.g., result = run(test, inputs)
 
     describe 'when the tester-provided notification bundle is not valid' do
       it 'fails when the notification bundle is not json' do


### PR DESCRIPTION
# Summary

Add unit tests for the client suite and also start to build standard unit test infrastructure for Inferno unit tests.

# Unit Testing Shared Artifacts

Created a suite rspec `[shared_context](https://github.com/inferno-framework/subscriptions-test-kit/blob/client-suite-unit-tests/spec/subscriptions_test_kit/suite_spec_context.rb)` that gets included at the top of the unit test to define variables and functions that are expected to be used in most unit tests. Currently, these include
- `suite`: the suite found in the TestSuite Repository
- `suite_id`: the suite id
- `session_data_repo`: session data repository
- `validation_url`: url for validator requests
- `test_session`: session data for this suite's run
- `run`: function to execute a specific runnable
- `find_test`: function to find a specific runnable within the suite - used to get the runnable to execute. This is an attempt to make a simple interface for finding the test by always loading the full suite and finding a specific test within it.

Questions for reviewers:
- Do these seem like functions and variables that will be used by all inferno unit tests? Anything you would remove because it won't be typically used?
- Any other functions / variables that will usually be used that should be added here?
- Is loading the whole suite and finding a specific test within it the right default pattern? I've seen some unit tests that more directly create tests, but seems like it sometimes causes problems when it references its parents in some way (can find an example if you're not sure what I mean.

# Unit Testing Patterns

I created [one spec file](https://github.com/inferno-framework/subscriptions-test-kit/blob/client-suite-unit-tests/spec/subscriptions_test_kit/suites/subscription_r5_backport_r4_client/workflow/interaction_test_spec.rb) for a [test](https://github.com/inferno-framework/subscriptions-test-kit/blob/client-suite-unit-tests/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow/interaction_test.rb) that includes what I think can be some standard patterns. I included some documentation of them in that class that would probably be moved elsewhere eventually.

## Execution with tester-inputs

The test requires tester inputs, specifically an access token and a notification Bundle.  The unit test contains a pattern for instantiating the test and executing it.

## Wait Tests

This test includes some verification before a wait dialog. The unit test contains a pattern for testing that the wait can be completed as expected.

Questions for reviewers:
- Does this look like the right pattern for wait tests?

## Additional Potential Patterns

- Responses from the system under test, e.g., `stub_request(:get, "#{export_url}?_outputFormat=application%2Fndjson").to_return(status: 400)`
- Requests from the system under test, e.g., `post(...)` (similar to wait stuff)
- Static method call responses and properties like scratch and suite options, e.g., `allow_any_instance_of(test).to(eceive(:suite_options).and_return(ONCCertificationG10TestKit::G10Options::US_CORE_3_REQUIREMENT)`
- Stored Tagged requests, e.g., `result = repo_create(:result, test_session_id: test_session.id)` and `repo_create(:request, result_id: result.id, name: 'questionnaire_package', request_body: nil, test_session_id: test_session.id, tags: [DaVinciDTRTestKit::QUESTIONNAIRE_PACKAGE_TAG])`
- inspecting messages in results, e.g., [todo - how?]
- look at requests associated with the results, e.g., [todo - how?]
- Dynamically create a test that runs specific sub-logic (used by multiple tests)

# Testing Guidance

run rspec using `bundle exec rspec`