### PR TITLE
Correctly add authorization header to Subscription.channel.header

### DIFF
--- a/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
+++ b/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
@@ -77,7 +77,7 @@ module SubscriptionsTestKit
           Added the Authorization header field with a Bearer token set to #{access_token} to the `header` field on the
           Subscription resource in order to connect successfully with the Inferno subscription channel.
         ))
-        subscription_channel['header'] = [] unless subscription['header'].present?
+        subscription_channel['header'] = [] unless subscription_channel['header'].present?
         subscription_channel['header'].append("Authorization: Bearer #{access_token}")
       end
       subscription['channel'] = subscription_channel

--- a/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
+++ b/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
@@ -77,8 +77,8 @@ module SubscriptionsTestKit
           Added the Authorization header field with a Bearer token set to #{access_token} to the `header` field on the
           Subscription resource in order to connect successfully with the Inferno subscription channel.
         ))
-        subscription['header'] = [] unless subscription['header'].present?
-        subscription['header'].append("Authorization: Bearer #{access_token}")
+        subscription_channel['header'] = [] unless subscription['header'].present?
+        subscription_channel['header'].append("Authorization: Bearer #{access_token}")
       end
       subscription['channel'] = subscription_channel
       subscription


### PR DESCRIPTION
# Summary

Previously, when the Subscription Server tests tried to add a Subscription.channel.header value with a bearer token, it did so at the Subscription level instead. Now it does so correctly.

# Testing Guidance

Run the Server tests agains the client tests following the instructions - see suite instructions - but removing the `"header": ["Authorization: Bearer SAMPLE_TOKEN"],` row from the *Workflow Subscription Resource* input on the server tests. Verify that the tests run correctly and that when viewing the client test responsible for verifying the Subscription creation (1.3.01 - Client Subscription Conformance Verification) that the Subscription creation request includes that content under Subscription.channel.