### PR TITLE
Release 0.10.0

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,3 +1,19 @@
+## 0.10.0
+
+### Breaking changes by @vanessuniq in https://github.com/inferno-framework/subscriptions-test-kit/pull/19:
+* Ruby Version Update: Upgraded Ruby to 3.3.6.
+* Inferno Core Update: Bumped to version 0.6.
+* Gemspec Updates:
+  * Switched to git for specifying files.
+  * Added presets to the gem package.
+  * Updated any test kit dependencies
+* Test Kit Metadata: Implemented Test Kit metadata for Inferno Platform.
+* Environment Updates: Updated Ruby version in the Dockerfile and GitHub Actions workflow.
+
+### Additional changes:
+* Fix subscription status endpoint bug by @tstrass in https://github.com/inferno-framework/subscriptions-test-kit/pull/21
+* FI-3243: User-experience Improvements by @karlnaden in https://github.com/inferno-framework/subscriptions-test-kit/pull/18
+
 ## 0.9.4
 
 * Correctly add authorization header to Subscription.channel.header by @karlnaden in https://github.com/inferno-framework/subscriptions-test-kit/pull/14

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    subscriptions_test_kit (0.9.4)
+    subscriptions_test_kit (0.10.0)
       inferno_core (~> 0.6.4)
 
 GEM

--- a/lib/subscriptions_test_kit/version.rb
+++ b/lib/subscriptions_test_kit/version.rb
@@ -1,4 +1,4 @@
 module SubscriptionsTestKit
-  VERSION = '0.9.4'.freeze
-  LAST_UPDATED = '2025-02-04'.freeze # TODO: update next release
+  VERSION = '0.10.0'.freeze
+  LAST_UPDATED = '2025-02-25'.freeze
 end


### PR DESCRIPTION
## Breaking Changes:
- **Ruby Version Update:** Upgraded Ruby to `3.3.6`.
- **Inferno Core Update:** Bumped to version `0.6`.
- **Gemspec Updates:**
  - Switched to `git` for specifying files.
  - Added `presets` to the gem package.
  - Updated any test kit dependencies
- **Test Kit Metadata:** Implemented Test Kit metadata for Inferno Platform.
- **Environment Updates:** Updated Ruby version in the Dockerfile and GitHub Actions workflow.
