### PR TITLE
Fix subscription status endpoint bug

### DIFF
--- a/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
+++ b/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
@@ -53,7 +53,7 @@ module SubscriptionsTestKit
 
       status_params = find_params(params, 'status')
       subscription_status = determine_subscription_status_code(subscription.id)
-      status_params.nil? || status_params.none? || status_params.any { p.valueString == subscription_status }
+      status_params.nil? || status_params.none? || status_params.any? { |p| p.valueString == subscription_status }
     end
 
     def tags

--- a/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
+++ b/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
@@ -30,7 +30,7 @@ module SubscriptionsTestKit
           return
         end
 
-        unless subscription_params_match?(params)
+        unless subscription_params_match?(params, subscription)
           not_found
           return
         end
@@ -46,7 +46,7 @@ module SubscriptionsTestKit
                                            event_count, request.url).to_json
     end
 
-    def subscription_params_match?(params)
+    def subscription_params_match?(params, subscription)
       id_params = find_params(params, 'id')
 
       return false if id_params&.any? && id_params&.none? { |p| p.valueString == subscription.id }

--- a/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
+++ b/lib/subscriptions_test_kit/endpoints/subscription_status_endpoint.rb
@@ -53,7 +53,7 @@ module SubscriptionsTestKit
 
       status_params = find_params(params, 'status')
       subscription_status = determine_subscription_status_code(subscription.id)
-      status_params.nil? || status_params.none? || status_params.any? { |p| p.valueString == subscription_status }
+      status_params.blank? || status_params.any? { |p| p.valueString == subscription_status }
     end
 
     def tags


### PR DESCRIPTION
# Summary

This fixes a bug which resulted in the resource-level subscription status endpoint to result in a 500 error.

# Testing Guidance

Hit the endpoint with postman.