### PR TITLE
FI-3625: Statically define Suite ID in URLs

### DIFF
--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow/conformance_verification/processing_attestation_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow/conformance_verification/processing_attestation_test.rb
@@ -27,9 +27,9 @@ module SubscriptionsTestKit
           message: %(
             I attest that the client application successfully processed the event notification sent by Inferno.
 
-            [Click here](#{resume_pass_url}?test_run_identifier=#{token}) if the above statement is **true**.
+            [Click here](#{resume_pass_url_client}?test_run_identifier=#{token}) if the above statement is **true**.
 
-            [Click here](#{resume_fail_url}?test_run_identifier=#{token}) if the above statement is **false**.
+            [Click here](#{resume_fail_url_client}?test_run_identifier=#{token}) if the above statement is **false**.
           )
         )
       end

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow/interaction_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow/interaction_test.rb
@@ -101,10 +101,10 @@ module SubscriptionsTestKit
             At any point while this test is waiting, Inferno will respond to Subscription GET and $status requests.
 
             Once the client has received an event notification and has made any additional requests,
-            [click here to complete the test](#{resume_pass_url}?test_run_identifier=#{access_token})
+            [click here to complete the test](#{resume_pass_url_client}?test_run_identifier=#{access_token})
 
             If at any point something has gone wrong and the client is unable to continue,
-            [click here to fail the test](#{resume_fail_url}?test_run_identifier=#{access_token})
+            [click here to fail the test](#{resume_fail_url_client}?test_run_identifier=#{access_token})
 
             NOTE: The test must be completed or failed using the links above within 10 minutes. After that,
             attempts to send requests or to complete or fail the tests using the links above

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/notification_delivery_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/notification_delivery_test.rb
@@ -45,8 +45,8 @@ module SubscriptionsTestKit
 
             `#{subscription_channel_url}`
 
-            [Click here](#{resume_pass_url_server}?token=notification%20#{access_token}) when you have finished submitting
-            requests.
+            [Click here](#{resume_pass_url_server}?token=notification%20#{access_token}) when you have finished
+            submitting requests.
 
           )
         )

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/notification_delivery_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/notification_delivery_test.rb
@@ -45,7 +45,7 @@ module SubscriptionsTestKit
 
             `#{subscription_channel_url}`
 
-            [Click here](#{resume_pass_url}?token=notification%20#{access_token}) when you have finished submitting
+            [Click here](#{resume_pass_url_server}?token=notification%20#{access_token}) when you have finished submitting
             requests.
 
           )

--- a/lib/subscriptions_test_kit/urls.rb
+++ b/lib/subscriptions_test_kit/urls.rb
@@ -10,28 +10,44 @@ module SubscriptionsTestKit
   RESUME_FAIL_PATH = '/resume_fail'
 
   module URLs
-    def base_url
-      @base_url ||= "#{Inferno::Application['base_url']}/custom/#{suite_id}"
+    def server_suite_base_url
+      @server_suite_base_url ||= "#{Inferno::Application['base_url']}/custom/#{server_suite_id}"
+    end
+
+    def client_suite_base_url
+      @client_suite_base_url ||= "#{Inferno::Application['base_url']}/custom/#{client_suite_id}"
     end
 
     def subscription_channel_url
-      @subscription_channel_url ||= base_url + SUBSCRIPTION_CHANNEL_PATH
+      @subscription_channel_url ||= server_suite_base_url + SUBSCRIPTION_CHANNEL_PATH
+    end
+
+    def resume_pass_url_server
+      @resume_pass_url_server ||= server_suite_base_url + RESUME_PASS_PATH
+    end
+
+    def resume_fail_url_server
+      @resume_fail_url_server ||= server_suite_base_url + RESUME_FAIL_PATH
     end
 
     def fhir_subscription_url
-      @fhir_subscription_url ||= base_url + FHIR_SUBSCRIPTION_PATH
+      @fhir_subscription_url ||= client_suite_base_url + FHIR_SUBSCRIPTION_PATH
     end
 
-    def resume_pass_url
-      @resume_pass_url ||= base_url + RESUME_PASS_PATH
+    def resume_pass_url_client
+      @resume_pass_url_client ||= client_suite_base_url + RESUME_PASS_PATH
     end
 
-    def resume_fail_url
-      @resume_fail_url ||= base_url + RESUME_FAIL_PATH
+    def resume_fail_url_client
+      @resume_fail_url_client ||= client_suite_base_url + RESUME_FAIL_PATH
     end
 
-    def suite_id
-      self.class.suite.id
+    def server_suite_id
+      SubscriptionsR5BackportR4Server::SubscriptionsR5BackportR4ServerSuite.id
+    end
+
+    def client_suite_id
+      SubscriptionsR5BackportR4Client::SubscriptionsR5BackportR4ClientSuite.id
     end
   end
 end


### PR DESCRIPTION
# Summary

This is needed so that when you import the subscriptions test kit into another test kit, the URLs evaluate consistently in all contexts.

There is functionally no change to the subscriptions test kit in isolation.

# Testing Guidance

Run client suite against server suite, verify results haven't changed.