### PR TITLE
FI-3652: Allow nonconformant subscription and capability statement

### DIFF
--- a/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
+++ b/lib/subscriptions_test_kit/common/subscription_conformance_verification.rb
@@ -66,7 +66,6 @@ module SubscriptionsTestKit
                             profile_url: 'http://hl7.org/fhir/uv/subscriptions-backport/StructureDefinition/backport-subscription')
 
       cross_version_extension_check(subscription)
-      subscription
     end
 
     def server_check_channel(subscription, access_token)

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow_group.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_client/workflow_group.rb
@@ -13,7 +13,7 @@ module SubscriptionsTestKit
       title 'Demonstrate the Rest-Hook Subscription Workflow'
       description %(
         This test allows the tester to demonstrate the ability of the client
-        to request the= creation of a FHIR Subscription instance and receive
+        to request the creation of a FHIR Subscription instance and receive
         notifications for that Subscription.
 
         The tester must provide the body of an event notification

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/capability_statement/cs_conformance_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/capability_statement/cs_conformance_test.rb
@@ -21,9 +21,8 @@ module SubscriptionsTestKit
         fhir_get_capability_statement
         assert_response_status(200)
         assert_resource_type(:capability_statement)
-        assert_valid_resource
-
         scratch[:capability_statement] ||= resource
+        assert_valid_resource
 
         assert(resource.rest.present?, 'Capability Statement missing the `rest` field')
         rest_server = resource.rest.find { |elem| elem.mode == 'server' }

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/subscription_conformance_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/subscription_conformance_test.rb
@@ -59,16 +59,14 @@ module SubscriptionsTestKit
         omit_if subscription_resource.blank?, 'Did not input a Subscription resource of this type.'
         assert_valid_json(subscription_resource)
         assert_resource_type('Subscription', resource: FHIR.from_contents(subscription_resource))
-
         subscription = JSON.parse(subscription_resource)
+        server_check_channel(subscription, access_token)
 
-        begin
-          subscription_verification(subscription_resource)
-          no_error_verification('Subscription resource is not conformant.')
-          subscription = server_check_channel(subscription, access_token)
-        ensure
-          output updated_subscription: subscription.to_json
-        end
+        updated_subscription = subscription.to_json
+        output(updated_subscription:)
+
+        subscription_verification(updated_subscription)
+        no_error_verification('Subscription resource is not conformant.')
       end
     end
   end

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/subscription_conformance_test.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/interaction/subscription_conformance_test.rb
@@ -57,10 +57,18 @@ module SubscriptionsTestKit
 
       run do
         omit_if subscription_resource.blank?, 'Did not input a Subscription resource of this type.'
-        subscription = subscription_verification(subscription_resource)
-        no_error_verification('Subscription resource is not conformant.')
-        subscription = server_check_channel(subscription, access_token)
-        output updated_subscription: subscription.to_json
+        assert_valid_json(subscription_resource)
+        assert_resource_type('Subscription', resource: FHIR.from_contents(subscription_resource))
+
+        subscription = JSON.parse(subscription_resource)
+
+        begin
+          subscription_verification(subscription_resource)
+          no_error_verification('Subscription resource is not conformant.')
+          subscription = server_check_channel(subscription, access_token)
+        ensure
+          output updated_subscription: subscription.to_json
+        end
       end
     end
   end

--- a/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/subscription_creation.rb
+++ b/lib/subscriptions_test_kit/suites/subscriptions_r5_backport_r4_server/common/subscription_creation.rb
@@ -50,12 +50,13 @@ module SubscriptionsTestKit
       end
 
       def subscription_payload_type(subscription)
-        return unless subscription['channel']['_payload']
+        payload_extensions = subscription.dig('channel', '_payload', 'extension')
+        return unless payload_extensions
 
-        payload_extension = subscription['channel']['_payload']['extension'].find do |ext|
+        payload_type = payload_extensions.find do |ext|
           ext['url'].ends_with?('/backport-payload-content')
         end
-        payload_extension['valueCode']
+        payload_type&.dig('valueCode')
       end
 
       def send_subscription(subscription)


### PR DESCRIPTION
# Summary

Modify subscription and capability statement conformance tests so that subsequent tests can use non-conformant instances

Context/impetus for these changes: https://github.com/inferno-framework/davinci-pas-test-kit/pull/31#discussion_r2016662437

- Example test run with a non-conformant subscription. You can see that the issues caught, but subsequent tests still successfully carry on with subscription creation
  <img width="1029" alt="image" src="https://github.com/user-attachments/assets/4930e0b1-4e14-451e-9ce2-4925798d672e" />

- Example test run with a non-conformant capability statement. You can see that the issues caught, but the subsequent topic discovery test still works
  <img width="841" alt="image" src="https://github.com/user-attachments/assets/d2a5ebe6-3415-4211-8984-751542885370" />


# Testing Guidance

- Run any of the section 3 subgroups with conformant and non-conformant subscriptions, verify expected results
- Run the capability statement group and verify expected results
- For both of the above I just run against the client suite and used presets